### PR TITLE
Prompt queue for subsequent successful gens.

### DIFF
--- a/PROMPT_QUEUE_FEATURE.md
+++ b/PROMPT_QUEUE_FEATURE.md
@@ -1,0 +1,105 @@
+# Prompt Queue Feature
+
+## Overview
+The prompt queue feature allows users to create a queue of different prompts that will be used sequentially when generating multiple videos (videoGoal > 1). Instead of using the same prompt for all videos, each successful video generation will advance to the next prompt in the queue.
+
+## How It Works
+
+### Basic Flow
+1. User sets video goal to > 1 (e.g., 3 videos)
+2. User adds multiple prompts to the queue (e.g., 3 different prompts)
+3. User starts session
+4. System uses prompt #1 and retries until success
+5. When video #1 succeeds, system moves to prompt #2 and resets retry count
+6. Process continues until all videos are generated or session ends
+
+### Key Behaviors
+- **Current Prompt**: The prompt used for the current video attempt is determined by `getCurrentPrompt()`, which returns the prompt at `currentPromptIndex` from the queue, or falls back to `lastPromptValue` if the queue is empty
+- **Retry Count Reset**: When advancing to the next prompt, the retry count is reset to 0, giving each prompt a full allocation of retries
+- **Queue Management**: Queue can be edited before session starts but is locked during an active session
+- **Prompt Partials**: Users can use preset text snippets (Style, Lighting, Mood, etc.) when building prompts for the queue
+
+## UI Components
+
+### PromptQueue Component
+Located in: `extension/src/components/PromptQueue.tsx`
+
+Features:
+- **Add Prompts**: Textarea + "Add to Queue" button
+- **Edit Prompts**: Click grip icon to edit, with Save/Cancel buttons
+- **Remove Prompts**: Click X icon to remove from queue
+- **Reorder Prompts**: Arrow up/down buttons to move prompts
+- **Current Indicator**: "Current" badge shows which prompt is active
+- **Prompt Partials Integration**: Full access to preset text snippets when creating/editing prompts
+
+### Visual Indicators
+- Queue shows total count: "3 prompts"
+- Current prompt highlighted with primary border during active session
+- Current badge displayed on active prompt
+- Disabled state during session (no editing allowed)
+
+## Storage Structure
+
+### Persistent Data (chrome.storage.local)
+```typescript
+promptQueue: string[]  // Array of complete prompts
+```
+
+### Session Data (sessionStorage)
+```typescript
+currentPromptIndex: number  // Index of current prompt (0-based)
+```
+
+## API Methods (useGrokRetry)
+
+### Queue Management
+- `setPromptQueue(queue: string[])` - Replace entire queue
+- `addToPromptQueue(prompt: string)` - Append prompt to queue
+- `removeFromPromptQueue(index: number)` - Remove prompt at index
+- `updatePromptInQueue(index: number, prompt: string)` - Update prompt at index
+- `movePromptInQueue(fromIndex: number, toIndex: number)` - Reorder prompts
+- `getCurrentPrompt(): string` - Get the current prompt to use
+
+### Integration Points
+1. **startSession()**: Resets currentPromptIndex to 0
+2. **incrementVideosGenerated()**: 
+   - Increments videosGenerated
+   - If queue is not empty and more videos remain, advances currentPromptIndex
+   - Resets retryCount to 0 for the new prompt
+3. **handleSuccess()** in App.tsx: Uses `getCurrentPrompt()` for next video generation
+
+## Example Usage
+
+### Scenario: Generate 3 Videos with Different Prompts
+```
+Video Goal: 3
+Prompt Queue:
+  1. "A sunny day at the beach with waves"
+  2. "A mountain landscape with snow peaks"
+  3. "A forest path in autumn colors"
+
+Session Flow:
+- Start: Use prompt #1, retries 0/10
+- Moderation: retry with prompt #1, retries 1/10
+- Success: Video 1 complete, advance to prompt #2, retries 0/10
+- Success: Video 2 complete, advance to prompt #3, retries 0/10
+- Moderation: retry with prompt #3, retries 1/10
+- Success: Video 3 complete, session ends
+```
+
+## Testing
+Tests are located in: `extension/tests/unit/promptQueue.spec.ts`
+
+Coverage includes:
+- Queue initialization
+- Adding prompts to queue
+- Tracking current prompt index
+- Persistence to chrome storage
+- Index reset on session start
+
+## Future Enhancements (Not Implemented)
+- Import/export queue from file
+- Save/load named queue presets
+- Shuffle queue order
+- Auto-populate queue from prompt history
+- Validation for minimum queue size based on video goal

--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -1,0 +1,141 @@
+# Testing the Prompt Queue Feature
+
+## Build Instructions
+
+### Prerequisites
+- Node.js v18+ installed
+- npm installed
+- Chrome browser
+
+### Step 1: Clone and Navigate to Extension Directory
+```bash
+cd /path/to/grok-auto-retry/extension
+```
+
+### Step 2: Install Dependencies
+```bash
+npm install
+```
+
+### Step 3: Build the Extension
+```bash
+npm run build
+```
+
+This will:
+1. Run TypeScript compiler (`tsc`)
+2. Run Vite build in content mode
+3. Generate the `dist/` folder with all necessary files
+
+**Note:** You may see 3 TypeScript errors related to `NodeJS.Timeout` namespace - these are pre-existing issues in the codebase and do not affect the build. The build will still complete successfully and generate the dist folder.
+
+### Step 4: Load Unpacked Extension in Chrome
+
+1. Open Chrome and navigate to: `chrome://extensions/`
+2. Enable "Developer mode" (toggle in top-right corner)
+3. Click "Load unpacked"
+4. Navigate to and select: `/path/to/grok-auto-retry/extension/dist`
+5. The extension should now appear in your extensions list
+
+### Step 5: Test the Prompt Queue Feature
+
+1. Navigate to: `https://grok.com/imagine/post/[any-post-id]`
+2. The control panel should appear on the right side
+3. Look for the new **"Prompt Queue"** section below "Prompt Partials"
+
+## Testing the Feature
+
+### Basic Queue Operations
+
+**Add Prompts to Queue:**
+1. In the "Prompt Queue" section, type a prompt in the textarea
+2. (Optional) Click on Prompt Partials buttons to add preset text snippets
+3. Click "Add to Queue" button
+4. Repeat to add multiple prompts (e.g., 3 prompts for 3 videos)
+
+**Edit a Prompt:**
+1. Click the grip icon (≡) on any queued prompt
+2. Modify the prompt text in the textarea
+3. (Optional) Use Prompt Partials to add snippets
+4. Click "Save" to confirm or "Cancel" to discard
+
+**Remove a Prompt:**
+1. Click the X icon on any queued prompt
+
+**Reorder Prompts:**
+1. Use ↑ and ↓ arrow buttons to move prompts up or down in the queue
+
+### Test Sequential Video Generation
+
+**Setup:**
+1. Set "Video goal" to 3 (or match your queue size)
+2. Add 3 different prompts to the queue
+3. Enable "Auto-retry"
+4. Set "Max retries" as desired
+
+**Run:**
+1. Click "Start Session"
+2. System will use prompt #1 from the queue
+3. When video #1 succeeds:
+   - Progress shows "1/3 videos"
+   - System automatically advances to prompt #2
+   - Retry count resets to 0
+   - "Current" badge moves to prompt #2
+4. Process continues until all 3 videos are generated
+
+**Expected Behavior:**
+- Each prompt is marked with "Current" badge when active
+- Retry count resets when moving to next prompt
+- Queue is locked (disabled) during active session
+- Session completes when videoGoal is reached
+
+### Verify Storage
+
+**Chrome DevTools:**
+1. Open DevTools (F12)
+2. Go to Application tab → Storage
+3. Check **Local Storage** → `chrome-extension://[extension-id]`
+4. Look for keys like `grokRetryPost_[postId]`
+5. Verify `promptQueue` array is saved
+
+## Troubleshooting
+
+### Extension Doesn't Appear
+- Make sure you selected the `dist` folder, not the `extension` folder
+- Check the Extensions page for any errors
+- Try disabling and re-enabling the extension
+
+### Build Errors
+- Run `npm install` again to ensure all dependencies are installed
+- Clear node_modules and reinstall: `rm -rf node_modules && npm install`
+- The 3 NodeJS.Timeout errors are expected and won't prevent the build
+
+### Prompt Queue Not Visible
+- Refresh the Grok page after loading the extension
+- Make sure you're on a `/imagine/post/*` route (not just `/imagine`)
+- Check browser console for any JavaScript errors
+
+### Queue Not Working
+- Ensure auto-retry is enabled
+- Verify video goal > 1
+- Check that prompts are actually in the queue (should show count badge)
+
+## Development Mode (Optional)
+
+For live development with hot reload:
+
+```bash
+npm run watch
+```
+
+This will:
+- Watch for file changes
+- Auto-rebuild on changes
+- You'll need to reload the extension in Chrome after each rebuild
+
+## Additional Notes
+
+- The extension requires the Grok.com website to function
+- Prompts are saved per post ID
+- Queue persists across page refreshes
+- Queue can only be edited when no session is active

--- a/extension/src/components/ControlPanel.tsx
+++ b/extension/src/components/ControlPanel.tsx
@@ -21,6 +21,7 @@ import { MaxRetriesControls } from "./MaxRetriesControls";
 import { VideoGoalControls } from "./VideoGoalControls";
 import { PromptTextarea } from "./PromptTextarea";
 import { PromptPartials } from "./PromptPartials";
+import { PromptQueue } from "./PromptQueue";
 import { ActionButton } from "./ActionButton";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import type { PromptHistoryRecord } from "@/hooks/usePromptHistory";
@@ -50,6 +51,8 @@ interface ControlPanelProps {
 	videosGenerated: number;
 	promptValue: string;
 	isSessionActive: boolean;
+	promptQueue: string[];
+	currentPromptIndex: number;
 	onResizeStart: (e: React.MouseEvent) => void;
 	onMinimize: () => void;
 	onMaximizeToggle: () => void;
@@ -63,6 +66,10 @@ interface ControlPanelProps {
 	onCopyToSite: () => void;
 	onGenerateVideo: () => void;
 	onCancelSession: () => void;
+	onAddToPromptQueue: (prompt: string) => void;
+	onRemoveFromPromptQueue: (index: number) => void;
+	onUpdatePromptInQueue: (index: number, prompt: string) => void;
+	onMovePromptInQueue: (fromIndex: number, toIndex: number) => void;
 	logs?: string[];
 	showDebug: boolean;
 	setShowDebug: (value: boolean) => void;
@@ -91,6 +98,8 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
 	videosGenerated,
 	promptValue,
 	isSessionActive,
+	promptQueue,
+	currentPromptIndex,
 	onResizeStart,
 	onMinimize,
 	onMaximizeToggle,
@@ -104,6 +113,10 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
 	onCopyToSite,
 	onGenerateVideo,
 	onCancelSession,
+	onAddToPromptQueue,
+	onRemoveFromPromptQueue,
+	onUpdatePromptInQueue,
+	onMovePromptInQueue,
 	logs = [],
 	showDebug,
 	setShowDebug,
@@ -572,6 +585,17 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
 				/>
 
 				<PromptPartials onAppendPartial={onPromptAppend} disabled={!autoRetryEnabled} />
+
+				<PromptQueue
+					promptQueue={promptQueue}
+					currentPromptIndex={currentPromptIndex}
+					isSessionActive={isSessionActive}
+					disabled={isSessionActive}
+					onAddPrompt={onAddToPromptQueue}
+					onRemovePrompt={onRemoveFromPromptQueue}
+					onUpdatePrompt={onUpdatePromptInQueue}
+					onMovePrompt={onMovePromptInQueue}
+				/>
 			</div>
 		);
 	}

--- a/extension/src/components/PromptQueue.tsx
+++ b/extension/src/components/PromptQueue.tsx
@@ -1,0 +1,247 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { Plus, X, GripVertical, ArrowUp, ArrowDown } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { PromptPartials } from "./PromptPartials";
+
+interface PromptQueueProps {
+	promptQueue: string[];
+	currentPromptIndex: number;
+	isSessionActive: boolean;
+	disabled?: boolean;
+	onAddPrompt: (prompt: string) => void;
+	onRemovePrompt: (index: number) => void;
+	onUpdatePrompt: (index: number, prompt: string) => void;
+	onMovePrompt: (fromIndex: number, toIndex: number) => void;
+}
+
+export const PromptQueue: React.FC<PromptQueueProps> = ({
+	promptQueue,
+	currentPromptIndex,
+	isSessionActive,
+	disabled = false,
+	onAddPrompt,
+	onRemovePrompt,
+	onUpdatePrompt,
+	onMovePrompt,
+}) => {
+	const [newPrompt, setNewPrompt] = React.useState("");
+	const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
+	const [editValue, setEditValue] = React.useState("");
+
+	const handleAddPrompt = () => {
+		if (newPrompt.trim()) {
+			onAddPrompt(newPrompt.trim());
+			setNewPrompt("");
+		}
+	};
+
+	const handleStartEdit = (index: number) => {
+		setEditingIndex(index);
+		setEditValue(promptQueue[index]);
+	};
+
+	const handleSaveEdit = () => {
+		if (editingIndex !== null && editValue.trim()) {
+			onUpdatePrompt(editingIndex, editValue.trim());
+			setEditingIndex(null);
+			setEditValue("");
+		}
+	};
+
+	const handleCancelEdit = () => {
+		setEditingIndex(null);
+		setEditValue("");
+	};
+
+	const handleMoveUp = (index: number) => {
+		if (index > 0) {
+			onMovePrompt(index, index - 1);
+		}
+	};
+
+	const handleMoveDown = (index: number) => {
+		if (index < promptQueue.length - 1) {
+			onMovePrompt(index, index + 1);
+		}
+	};
+
+	const handlePromptAppend = (partial: string, position: "prepend" | "append") => {
+		// Check if partial content already exists in the new prompt
+		const partialContent = partial.trim().replace(/\.$/, "");
+		if (newPrompt.toLowerCase().includes(partialContent.toLowerCase())) {
+			return; // Already exists, don't add
+		}
+
+		const updatedPrompt = position === "prepend" ? partial + newPrompt : newPrompt + partial;
+		setNewPrompt(updatedPrompt);
+	};
+
+	const handleEditPromptAppend = (partial: string, position: "prepend" | "append") => {
+		if (editingIndex === null) return;
+
+		// Check if partial content already exists in the edit value
+		const partialContent = partial.trim().replace(/\.$/, "");
+		if (editValue.toLowerCase().includes(partialContent.toLowerCase())) {
+			return; // Already exists, don't add
+		}
+
+		const updatedPrompt = position === "prepend" ? partial + editValue : editValue + partial;
+		setEditValue(updatedPrompt);
+	};
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Label className="text-sm cursor-help">Prompt Queue</Label>
+					</TooltipTrigger>
+					<TooltipContent>
+						Queue multiple prompts. When video goal &gt; 1, each video uses the next prompt in the queue.
+					</TooltipContent>
+				</Tooltip>
+				<Badge variant="outline" className="text-xs">
+					{promptQueue.length} prompt{promptQueue.length !== 1 ? "s" : ""}
+				</Badge>
+			</div>
+
+			{promptQueue.length > 0 && (
+				<div className="space-y-2 max-h-[200px] overflow-y-auto border border-border rounded-md p-2">
+					{promptQueue.map((prompt, index) => (
+						<div
+							key={index}
+							className={`relative rounded-md border p-2 ${
+								index === currentPromptIndex && isSessionActive
+									? "border-primary bg-primary/5"
+									: "border-border bg-muted/20"
+							}`}
+						>
+							{editingIndex === index ? (
+								<div className="space-y-2">
+									<Textarea
+										value={editValue}
+										onChange={(e) => setEditValue(e.target.value)}
+										className="min-h-[60px] text-xs"
+										disabled={disabled}
+									/>
+									<PromptPartials onAppendPartial={handleEditPromptAppend} disabled={disabled} />
+									<div className="flex gap-1">
+										<Button
+											size="sm"
+											variant="default"
+											onClick={handleSaveEdit}
+											disabled={disabled || !editValue.trim()}
+											className="h-6 text-xs"
+										>
+											Save
+										</Button>
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={handleCancelEdit}
+											disabled={disabled}
+											className="h-6 text-xs"
+										>
+											Cancel
+										</Button>
+									</div>
+								</div>
+							) : (
+								<>
+									<div className="flex items-start gap-2">
+										<div className="flex flex-col gap-0.5">
+											<Button
+												size="sm"
+												variant="ghost"
+												onClick={() => handleMoveUp(index)}
+												disabled={disabled || index === 0}
+												className="h-4 w-4 p-0"
+											>
+												<ArrowUp className="h-3 w-3" />
+											</Button>
+											<Button
+												size="sm"
+												variant="ghost"
+												onClick={() => handleMoveDown(index)}
+												disabled={disabled || index === promptQueue.length - 1}
+												className="h-4 w-4 p-0"
+											>
+												<ArrowDown className="h-3 w-3" />
+											</Button>
+										</div>
+										<div className="flex-1 min-w-0">
+											<div className="flex items-center gap-2 mb-1">
+												<Badge variant="secondary" className="text-xs h-4 px-1">
+													#{index + 1}
+												</Badge>
+												{index === currentPromptIndex && isSessionActive && (
+													<Badge variant="default" className="text-xs h-4 px-1">
+														Current
+													</Badge>
+												)}
+											</div>
+											<p className="text-xs text-muted-foreground line-clamp-2 break-words">
+												{prompt}
+											</p>
+										</div>
+										<div className="flex gap-1">
+											<Button
+												size="sm"
+												variant="ghost"
+												onClick={() => handleStartEdit(index)}
+												disabled={disabled}
+												className="h-6 w-6 p-0"
+											>
+												<GripVertical className="h-3 w-3" />
+											</Button>
+											<Button
+												size="sm"
+												variant="ghost"
+												onClick={() => onRemovePrompt(index)}
+												disabled={disabled}
+												className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+											>
+												<X className="h-3 w-3" />
+											</Button>
+										</div>
+									</div>
+								</>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+
+			{!disabled && (
+				<div className="space-y-2">
+					<Textarea
+						placeholder="Enter a new prompt to add to queue..."
+						className="min-h-[60px] text-xs"
+						value={newPrompt}
+						onChange={(e) => setNewPrompt(e.target.value)}
+						disabled={disabled}
+					/>
+					<PromptPartials onAppendPartial={handlePromptAppend} disabled={disabled} />
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={handleAddPrompt}
+						disabled={disabled || !newPrompt.trim()}
+						className="w-full h-7 text-xs"
+					>
+						<Plus className="h-3 w-3 mr-1" />
+						Add to Queue
+					</Button>
+				</div>
+			)}
+
+			{promptQueue.length === 0 && disabled && (
+				<p className="text-xs text-muted-foreground text-center py-4">No prompts in queue</p>
+			)}
+		</div>
+	);
+};

--- a/extension/src/content/App.tsx
+++ b/extension/src/content/App.tsx
@@ -77,6 +77,13 @@ const ImaginePostApp: React.FC = () => {
 		clearLogs,
 		lastSessionOutcome,
 		lastSessionSummary,
+		promptQueue,
+		currentPromptIndex,
+		addToPromptQueue,
+		removeFromPromptQueue,
+		updatePromptInQueue,
+		movePromptInQueue,
+		getCurrentPrompt,
 	} = retry;
 	const { data: uiPrefs, save: saveUIPref } = useStorage();
 	const { capturePromptFromSite, copyPromptToSite, setupClickListener } = usePromptCapture();
@@ -229,7 +236,9 @@ const ImaginePostApp: React.FC = () => {
 				}
 				// Do not reset retryCount; maxRetries applies to whole session
 				// Use overridePermit since this is a new video generation, not a retry
-				clickMakeVideoButton(lastPromptValue, { overridePermit: true });
+				const nextPrompt = getCurrentPrompt();
+				console.log(`[Grok Retry] Using prompt for next video: ${nextPrompt ? nextPrompt.substring(0, 50) + '...' : '(empty)'}`);
+				clickMakeVideoButton(nextPrompt, { overridePermit: true });
 				nextVideoTimeoutRef.current = null;
 			}, 8000);
 		}
@@ -240,7 +249,7 @@ const ImaginePostApp: React.FC = () => {
 		endSession,
 		isSessionActive,
 		clickMakeVideoButton,
-		lastPromptValue,
+		getCurrentPrompt,
 		recordPromptOutcome,
 	]);
 
@@ -502,6 +511,8 @@ const ImaginePostApp: React.FC = () => {
 					videosGenerated={videosGenerated}
 					promptValue={lastPromptValue}
 					isSessionActive={isSessionActive}
+					promptQueue={promptQueue}
+					currentPromptIndex={currentPromptIndex}
 					onResizeStart={panelResize.handleResizeStart}
 					onMinimize={() => saveUIPref("isMinimized", true)}
 					onMaximizeToggle={handleMaximizeToggle}
@@ -515,6 +526,10 @@ const ImaginePostApp: React.FC = () => {
 					onCopyToSite={handleCopyToSite}
 					onGenerateVideo={handleGenerateVideo}
 					onCancelSession={handleCancelSession}
+					onAddToPromptQueue={addToPromptQueue}
+					onRemoveFromPromptQueue={removeFromPromptQueue}
+					onUpdatePromptInQueue={updatePromptInQueue}
+					onMovePromptInQueue={movePromptInQueue}
 					logs={logs || []}
 					showDebug={showDebug}
 					setShowDebug={setShowDebug}

--- a/extension/tests/unit/promptQueue.spec.ts
+++ b/extension/tests/unit/promptQueue.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const GLOBAL_SETTINGS_KEY = 'grokRetry_globalSettings';
+const PERSISTENT_PREFIX = 'grokRetryPost_';
+const SESSION_PREFIX = 'grokRetrySession_';
+
+interface StorageBacking {
+    [key: string]: any;
+}
+
+const createStorageArea = (backing: StorageBacking) => ({
+    get(keys: string | string[] | Record<string, any>, callback: (items: Record<string, any>) => void) {
+        const result: Record<string, any> = {};
+        const keyArray = Array.isArray(keys)
+            ? keys
+            : typeof keys === 'string'
+                ? [keys]
+                : keys && typeof keys === 'object'
+                    ? Object.keys(keys)
+                    : [];
+
+        keyArray.forEach((key) => {
+            if (Object.prototype.hasOwnProperty.call(backing, key)) {
+                result[key] = backing[key];
+            } else if (keys && typeof keys === 'object' && !Array.isArray(keys)) {
+                result[key] = (keys as Record<string, any>)[key];
+            } else {
+                result[key] = undefined;
+            }
+        });
+
+        callback(result);
+    },
+    set(items: Record<string, any>, callback?: () => void) {
+        Object.entries(items).forEach(([key, value]) => {
+            backing[key] = value;
+        });
+        callback?.();
+    },
+});
+
+describe('Prompt Queue', () => {
+    const postId = 'test-post';
+    const persistentKey = `${PERSISTENT_PREFIX}${postId}`;
+
+    let localBacking: StorageBacking;
+    let syncBacking: StorageBacking;
+    let usePostStorage: any;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        sessionStorage.clear();
+
+        localBacking = {};
+        syncBacking = {
+            [GLOBAL_SETTINGS_KEY]: {},
+        };
+
+        (globalThis as any).chrome = {
+            storage: {
+                local: createStorageArea(localBacking),
+                sync: createStorageArea(syncBacking),
+            },
+            runtime: { lastError: null },
+        };
+
+        const mod = await import('../../src/hooks/useSessionStorage');
+        usePostStorage = mod.usePostStorage;
+    });
+
+    afterEach(() => {
+        delete (globalThis as any).chrome;
+    });
+
+    it('initializes with empty prompt queue', async () => {
+        const { result } = renderHook(() => usePostStorage(postId, null));
+
+        await vi.waitFor(() => !result.current.isLoading);
+
+        expect(result.current.data.promptQueue).toEqual([]);
+        expect(result.current.data.currentPromptIndex).toBe(0);
+    });
+
+    it('adds prompts to queue', async () => {
+        const { result } = renderHook(() => usePostStorage(postId, null));
+
+        await vi.waitFor(() => !result.current.isLoading);
+
+        act(() => {
+            result.current.save('promptQueue', ['Prompt 1', 'Prompt 2', 'Prompt 3']);
+        });
+
+        expect(result.current.data.promptQueue).toEqual(['Prompt 1', 'Prompt 2', 'Prompt 3']);
+    });
+
+    it('tracks current prompt index', async () => {
+        const { result } = renderHook(() => usePostStorage(postId, null));
+
+        await vi.waitFor(() => !result.current.isLoading);
+
+        act(() => {
+            result.current.saveAll({
+                promptQueue: ['Prompt 1', 'Prompt 2', 'Prompt 3'],
+                currentPromptIndex: 1,
+            });
+        });
+
+        expect(result.current.data.currentPromptIndex).toBe(1);
+    });
+
+    it('persists prompt queue to chrome storage', async () => {
+        const { result } = renderHook(() => usePostStorage(postId, null));
+
+        await vi.waitFor(() => !result.current.isLoading);
+
+        act(() => {
+            result.current.save('promptQueue', ['Prompt A', 'Prompt B']);
+        });
+
+        expect(localBacking[persistentKey]).toBeDefined();
+        expect(localBacking[persistentKey].promptQueue).toEqual(['Prompt A', 'Prompt B']);
+    });
+
+    it('resets current prompt index on session start', async () => {
+        const { result } = renderHook(() => usePostStorage(postId, null));
+
+        await vi.waitFor(() => !result.current.isLoading);
+
+        // Set up some state
+        act(() => {
+            result.current.saveAll({
+                currentPromptIndex: 2,
+                isSessionActive: false,
+            });
+        });
+
+        expect(result.current.data.currentPromptIndex).toBe(2);
+
+        // Start session should reset index to 0
+        act(() => {
+            result.current.saveAll({
+                currentPromptIndex: 0,
+                isSessionActive: true,
+            });
+        });
+
+        expect(result.current.data.currentPromptIndex).toBe(0);
+    });
+});


### PR DESCRIPTION
I saw a post in your thread suggesting this.
Copilot whipped up a decent feature addition here. I'm running it, and other than a queue # offset (if the original box is left blank) I think it's working well so far in testing.
See if you like it?

