### PR TITLE
feat: Preserve original image ID across video generation sessions

### DIFF
--- a/docs/original-image-id-preservation.md
+++ b/docs/original-image-id-preservation.md
@@ -1,0 +1,442 @@
+# Original Image ID Preservation
+
+## Overview
+
+This document explains how the extension ensures that all video generation attempts within a session reference the **same source image**, even when generating multiple videos (videoGoal > 1) that cause page navigation.
+
+## The Problem
+
+When generating multiple videos from a single image:
+
+1. User starts on `/imagine/post/{postId1}` with an image (mediaId: `abc123`)
+2. First video is generated successfully
+3. Grok's UI navigates to `/imagine/post/{postId2}` (new post for the video)
+4. Session continues to generate video #2
+5. **Issue**: `findPrimaryMediaId()` now detects a different image in the DOM
+6. Subsequent videos might be generated from wrong image or fail
+
+## The Solution
+
+### 1. Capture Original Image ID
+
+When a session starts in `useGrokRetry.startSession()`:
+
+```typescript
+// Store the original mediaId to ensure all video attempts reference the same source image
+const originalMediaIdToStore = mediaId ?? postData.originalMediaId ?? null;
+
+saveAll({
+  // ... other session data
+  originalMediaId: originalMediaIdToStore,
+});
+```
+
+**Logic:**
+- Use current `mediaId` if available (from URL detection)
+- Fall back to stored `postData.originalMediaId` if resuming a session
+- Store as `null` if no image ID is available
+
+### 2. Persist Across Sessions
+
+The `originalMediaId` is stored in **Chrome Storage (chrome.storage.local)**, making it:
+- Persistent across browser sessions
+- Synchronized with other persistent data (maxRetries, videoGoal, etc.)
+- Available for state migration during route changes
+
+**Data Structure:**
+```typescript
+interface PersistentData {
+  maxRetries: number;
+  autoRetryEnabled: boolean;
+  lastPromptValue: string;
+  videoGoal: number;
+  videoGroup: string[];
+  originalMediaId: string | null; // NEW: Original image ID
+}
+```
+
+### 3. Preserve During Route Changes
+
+When the page navigates during an active session (`usePostId.tsx`):
+
+```typescript
+// Update session tracking to use new post ID, but keep original media ID
+w.__grok_session_post_id = urlPostId;
+
+// Preserve sessionMediaId (original image ID) rather than replacing with nextMediaId
+if (!w.__grok_session_media_id && sessionMediaId) {
+  w.__grok_session_media_id = sessionMediaId;
+}
+```
+
+**Key Points:**
+- `__grok_session_post_id` updates to the new post (for route tracking)
+- `__grok_session_media_id` is **preserved** from the original session
+- Prevents the newly detected `nextMediaId` from overwriting the original
+
+### 4. Expose for Debugging
+
+The original media ID is exposed in multiple places for debugging:
+
+```typescript
+// In window.__grok_retryState
+window.__grok_retryState = {
+  isSessionActive: true,
+  retryCount: 1,
+  canRetry: false,
+  originalMediaId: 'abc123', // NEW
+};
+
+// In window.__grok_session_media_id
+window.__grok_session_media_id = 'abc123';
+
+// In hook return value
+const { originalMediaId } = useGrokRetry({ postId, mediaId });
+```
+
+### 5. Clear on Session End
+
+When the session ends:
+
+```typescript
+saveAll({
+  isSessionActive: false,
+  // ... reset counters
+  originalMediaId: null, // Clear original image ID
+});
+
+// Clear ALL video attempts that share this originalMediaId
+if (originalMediaId) {
+  clearVideoAttemptsByMediaId(originalMediaId, outcome);
+}
+```
+
+**Comprehensive Cleanup:**
+
+When a session ends (for any reason: success, failure, cancellation, timeout), the extension performs a comprehensive cleanup of all video generation attempts that share the same `originalMediaId`:
+
+1. **grokStream State** - Removes video attempts from the in-memory stream tracker
+   - Finds all `VideoAttemptState` records where `imageReference === originalMediaId`
+   - Removes them from the videos collection
+   - Updates parent sessions to remove references to these attempts
+
+2. **Chrome Storage** - Ends active sessions in persistent storage
+   - Scans all stored post data (`grokRetryPost_*` keys)
+   - Finds posts where `originalMediaId` matches and `isSessionActive === true`
+   - Marks them as inactive and resets their session state
+
+3. **Session Storage** - Clears temporary session data
+   - Scans all session storage entries (`grokRetrySession_*` keys)
+   - Marks active sessions as inactive
+   - Prevents zombie sessions from persisting after page refresh
+
+This ensures:
+- No orphaned video generation attempts remain active
+- All related sessions are properly terminated together
+- Clean state for future video generation sessions
+- Proper cleanup regardless of how the session ended
+
+## Implementation Details
+
+### Files Modified
+
+1. **`useSessionStorage.ts`**
+   - Added `originalMediaId` to `PersistentData` interface
+   - Updated default values to include `originalMediaId: null`
+
+2. **`useGrokRetry.ts`**
+   - Capture and store `originalMediaId` in `startSession()`
+   - Clear `originalMediaId` in `endSession()`
+   - Export `originalMediaId` from hook return value
+   - Expose in `window.__grok_retryState` for debugging
+
+3. **`usePostId.ts`**
+   - Preserve `sessionMediaId` during route migrations
+   - Prevent overwriting with newly detected `nextMediaId`
+
+### Behavior Flow
+
+```
+Session Start (post1, image: abc123)
+  ↓
+Store originalMediaId: 'abc123'
+Set __grok_session_media_id: 'abc123'
+  ↓
+Video #1 Generated Successfully
+  ↓
+Route Change: post1 → post2
+  ↓
+Detect route change during active session
+  ↓
+Migrate state: post1 → post2
+Preserve __grok_session_media_id: 'abc123' ✓
+  ↓
+Video #2 Attempt (still uses image: abc123)
+  ↓
+... continues until videoGoal reached
+  ↓
+Session End
+  ↓
+Clear originalMediaId: null
+Clear __grok_session_media_id
+```
+
+## Benefits
+
+1. **Consistency**: All videos in a session are generated from the same source image
+2. **Reliability**: Prevents failures due to missing/wrong image references
+3. **User Experience**: Users can confidently generate multiple video variations
+4. **Comprehensive Cleanup**: All related video attempts are properly terminated when session ends
+5. **No Orphaned State**: Prevents zombie sessions across storage layers
+6. **Debugging**: Easy to verify which image a session is using
+
+## Testing Scenarios
+
+### Scenario 1: Multi-Video Generation (videoGoal = 3)
+
+```
+1. User on /imagine/post/post1 with image abc123
+2. Click "Generate Video" with videoGoal = 3
+3. Session starts, stores originalMediaId = 'abc123'
+4. Video #1 generated → navigate to /imagine/post/post2
+5. Session continues, __grok_session_media_id still 'abc123' ✓
+6. Video #2 generated → navigate to /imagine/post/post3
+7. Session continues, __grok_session_media_id still 'abc123' ✓
+8. Video #3 generated → navigate to /imagine/post/post4
+9. Session ends, originalMediaId cleared
+10. All attempts for 'abc123' terminated ✓
+```
+
+**Expected**: All 3 videos use image `abc123`, all attempts properly cleaned up
+
+### Scenario 2: Session Cancelled Mid-Generation
+
+```
+1. User starts session with image abc123, videoGoal = 3
+2. Video #1 generated → navigate to /imagine/post/post2
+3. Video #2 in progress on /imagine/post/post3
+4. User clicks "Cancel Session"
+5. Session ends with outcome = 'cancelled'
+6. All attempts for 'abc123' terminated immediately ✓
+7. Active sessions across all storage layers cleared ✓
+```
+
+**Expected**: Immediate cleanup of all related attempts
+
+### Scenario 3: Multiple Concurrent Sessions (Different Images)
+
+```
+1. Tab 1: Session with image abc123, generating videos
+2. Tab 2: Session with image def456, generating videos
+3. Tab 1 session ends (success)
+4. Only attempts for 'abc123' are cleared ✓
+5. Tab 2 session continues unaffected ✓
+```
+
+**Expected**: Each session only clears its own image's attempts
+
+### Scenario 2: Session Interrupted and Resumed
+
+```
+1. User starts session with image abc123
+2. Video #1 generated, videoGoal = 3
+3. User refreshes page (session ends)
+4. All attempts for 'abc123' terminated ✓
+5. originalMediaId is cleared from active state
+6. User clicks "Generate Video" again
+7. New session starts with fresh originalMediaId = 'abc123'
+```
+
+**Expected**: Fresh start, previous attempts properly cleaned
+
+### Scenario 3: No Image Present
+
+```
+1. User on /imagine/post/post1 (text-only post, no image)
+2. mediaId = null
+3. Session starts, originalMediaId = null
+4. Video generation may use different logic (text-to-video)
+5. Session ends, no media-specific cleanup needed
+```
+
+**Expected**: No errors, gracefully handles null image ID
+
+## Future Enhancements
+
+1. **Image Reference Validation**: Verify the image still exists before each attempt
+2. **Explicit Image Selection**: Allow users to select which image to use for videos
+3. **Multi-Image Sessions**: Support generating videos from different images in sequence
+4. **Image Metadata**: Store additional image info (dimensions, URL) for reference
+
+## Debugging
+
+To check if the original image ID is being preserved:
+
+```javascript
+// Check current session state
+console.log(window.__grok_retryState.originalMediaId);
+
+// Check session media ID
+console.log(window.__grok_session_media_id);
+
+// Check stored persistent data
+chrome.storage.local.get(['grokRetryPost_{postId}'], (result) => {
+  console.log(result.grokRetryPost_{postId}.originalMediaId);
+});
+
+// Verify all attempts for an image were cleared
+chrome.storage.local.get(null, (allData) => {
+  const activeSessions = Object.entries(allData)
+    .filter(([key]) => key.startsWith('grokRetryPost_'))
+    .filter(([_, data]) => data.originalMediaId === 'abc123' && data.isSessionActive);
+  console.log('Active sessions for abc123:', activeSessions.length);
+  // Should be 0 after session ends
+});
+```
+
+Expected output during an active session:
+```javascript
+window.__grok_retryState.originalMediaId  // 'abc123'
+window.__grok_session_media_id            // 'abc123'
+```
+
+After session ends:
+```javascript
+window.__grok_retryState.originalMediaId  // null
+window.__grok_session_media_id            // undefined
+// All related attempts cleared from storage
+```
+
+## Cleanup Architecture
+
+The cleanup system operates across three storage layers to ensure complete termination:
+
+### Layer 1: grokStream (In-Memory)
+
+**Purpose**: Real-time video attempt tracking via GraphQL stream interception
+
+**Cleanup Function**: `clearVideoAttemptsByImageReference(imageReference)`
+
+```typescript
+export function clearVideoAttemptsByImageReference(imageReference: string | null) {
+  // Find all VideoAttemptState records with matching imageReference
+  // Remove from videos collection
+  // Update parent sessions to remove attempt references
+  // Notify all listeners of state change
+}
+```
+
+**Data Cleared**:
+- `VideoAttemptState` entries where `imageReference === originalMediaId`
+- Parent session references to cleared attempts
+- Stream event history related to those attempts
+
+### Layer 2: Chrome Storage (Persistent)
+
+**Purpose**: Long-term persistence across browser sessions
+
+**Cleanup Process**: Scans all `grokRetryPost_*` keys
+
+```typescript
+chrome.storage.local.get(null, (allData) => {
+  for (const [key, postData] of Object.entries(allData)) {
+    if (postData.originalMediaId === targetMediaId && postData.isSessionActive) {
+      // Mark as inactive and reset session state
+      chrome.storage.local.set({
+        [key]: {
+          ...postData,
+          isSessionActive: false,
+          retryCount: 0,
+          videosGenerated: 0,
+          canRetry: false,
+          lastSessionOutcome: outcome,
+        }
+      });
+    }
+  }
+});
+```
+
+**Data Cleared**:
+- Sets `isSessionActive = false` for matching posts
+- Resets session counters
+- Records final outcome
+- Preserves settings for future use
+
+### Layer 3: Session Storage (Temporary)
+
+**Purpose**: Per-page-load session data, cleared on refresh
+
+**Cleanup Process**: Scans all `grokRetrySession_*` keys
+
+```typescript
+for (const key of sessionKeys) {
+  const parsed = JSON.parse(sessionStorage.getItem(key));
+  if (parsed.isSessionActive) {
+    sessionStorage.setItem(key, JSON.stringify({
+      ...parsed,
+      isSessionActive: false,
+      canRetry: false,
+      retryCount: 0,
+      videosGenerated: 0,
+      lastSessionOutcome: outcome,
+    }));
+  }
+}
+```
+
+**Data Cleared**:
+- Marks all active sessions as inactive
+- Prevents stale session resumption after navigation
+- Clears retry permissions
+
+### Cleanup Sequence
+
+When `endSession(outcome)` is called:
+
+```
+1. resetProgressTracking()
+   └─ Stop MutationObserver
+   └─ Clear progress records
+
+2. Clear window globals
+   └─ delete __grok_session_post_id
+   └─ delete __grok_session_media_id
+   └─ delete route change flags
+
+3. clearVideoAttemptsByMediaId(originalMediaId, outcome)
+   └─ Layer 1: clearVideoAttemptsByImageReference()
+   │   ├─ Remove VideoAttemptState entries
+   │   └─ Update parent sessions
+   └─ Layer 2: Scan chrome.storage.local
+   │   └─ Mark matching posts inactive
+   └─ Layer 3: Scan sessionStorage
+       └─ Mark matching sessions inactive
+
+4. clearVideoGroupChain(outcome)
+   └─ Clear videoGroup arrays in related posts
+
+5. Create SessionSummary
+   └─ Record final statistics
+
+6. saveAll() to update current post state
+   └─ isSessionActive = false
+   └─ originalMediaId = null
+```
+
+### Why Three Layers?
+
+1. **grokStream**: Fast in-memory tracking, survives navigation within same page load
+2. **Chrome Storage**: Persists across refreshes and browser restarts, syncs across tabs
+3. **Session Storage**: Page-specific state, automatically cleared on full navigation
+
+This multi-layer approach ensures:
+- **Immediate cleanup** in active memory
+- **Persistent cleanup** for future page loads
+- **Complete cleanup** even if browser crashes or tabs are duplicated
+
+## Related Documentation
+
+- [Video Generation Lifecycle](./video-generation-lifecycle.md) - Complete session lifecycle
+- [Session Storage](../extension/src/hooks/useSessionStorage.ts) - Data persistence implementation
+- [Post ID Hook](../extension/src/hooks/usePostId.ts) - Route change detection

--- a/docs/video-generation-lifecycle.md
+++ b/docs/video-generation-lifecycle.md
@@ -1,0 +1,454 @@
+# Video Generation Session Lifecycle
+
+This document describes the complete lifecycle of a video generation session in the Grok Auto-Retry extension, including state management, retry logic, and multi-video generation.
+
+## Overview
+
+The extension manages video generation sessions through a state machine that handles:
+- **Session initialization** with prompt capture
+- **Automated retries** on moderation failures
+- **Multi-video generation** with configurable goals
+- **Progress tracking** and failure categorization
+- **Session termination** with outcome summaries
+
+## Session Lifecycle State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    
+    Idle --> SessionStart: User clicks Generate Video
+    
+    SessionStart --> AttemptVideo: Start attempt #1
+    
+    AttemptVideo --> CooldownWait: Button clicked, 8s cooldown starts
+    
+    CooldownWait --> DetectingOutcome: Waiting for success or failure
+    
+    DetectingOutcome --> Success: Video generated successfully
+    DetectingOutcome --> ModerationFailure: Content moderated
+    DetectingOutcome --> RateLimitFailure: Rate limit reached
+    DetectingOutcome --> SessionTimeout: No feedback for 2 minutes
+    
+    Success --> CheckVideoGoal: videosGenerated < videoGoal?
+    CheckVideoGoal --> NextVideoDelay: Yes, wait 8 seconds
+    CheckVideoGoal --> SessionEnd_Success: No, goal reached
+    
+    NextVideoDelay --> AttemptVideo: Continue with same prompt
+    
+    ModerationFailure --> ClassifyLayer: Determine failure layer by progress %
+    ClassifyLayer --> CheckRetryLimit: Classify and record layer
+    
+    CheckRetryLimit --> SchedulerRetry: retryCount < maxRetries
+    CheckRetryLimit --> SessionEnd_Failure: retryCount >= maxRetries
+    
+    SchedulerRetry --> CooldownWait: Scheduler increments and retries
+    
+    RateLimitFailure --> SessionEnd_Cancelled: Cancel session immediately
+    SessionTimeout --> SessionEnd_Cancelled: No response detected
+    
+    SessionEnd_Success --> GenerateSummary: Create session summary
+    SessionEnd_Failure --> GenerateSummary
+    SessionEnd_Cancelled --> GenerateSummary
+    
+    GenerateSummary --> ResetState: Clear session data
+    ResetState --> Idle
+    
+    note right of SessionStart
+        State Initialized:
+        • isSessionActive = true
+        • retryCount = 0
+        • videosGenerated = 0
+        • creditsUsed = 0
+        • layer failures = 0
+        • canRetry = false
+    end note
+    
+    note right of ClassifyLayer
+        Layer Classification:
+        Layer 1 (0-24%): Prompt filtering
+        Layer 2 (25-87%): Model alignment
+        Layer 3 (88-100%): Post-validation
+        
+        Actions:
+        • Records progress %
+        • Increments layer counter
+        • Increments creditsUsed
+        • Sets canRetry = true
+    end note
+    
+    note right of Success
+        Success Tracking:
+        • Increments videosGenerated
+        • Increments creditsUsed
+        • Records prompt outcome
+        • Checks video goal
+    end note
+    
+    note right of GenerateSummary
+        Summary Includes:
+        • outcome (success/failure/cancelled)
+        • completedVideos
+        • retriesAttempted
+        • creditsUsed
+        • layer1/2/3 failures
+        • endedAt timestamp
+    end note
+```
+
+## Key Components
+
+### Session States
+
+| State | Description |
+|-------|-------------|
+| **Idle** | No active session; waiting for user action |
+| **SessionStart** | Session initialized with prompt and settings |
+| **AttemptVideo** | Click attempt in progress |
+| **CooldownWait** | 8-second cooldown period after button click |
+| **DetectingOutcome** | Monitoring for success or failure signals |
+| **NextVideoDelay** | 8-second delay between multi-video generations |
+| **SessionEnd** | Terminal state with outcome (success/failure/cancelled) |
+
+### Session Data Structure
+
+```typescript
+interface SessionData {
+  // Active state
+  isSessionActive: boolean;
+  retryCount: number;
+  videosGenerated: number;
+  canRetry: boolean;
+  
+  // Timing
+  lastAttemptTime: number;
+  lastFailureTime: number;
+  
+  // Tracking
+  logs: string[];
+  attemptProgress: AttemptProgressEntry[];
+  creditsUsed: number;
+  
+  // Failure classification
+  layer1Failures: number;  // Prompt filtering (0-24%)
+  layer2Failures: number;  // Model alignment (25-87%)
+  layer3Failures: number;  // Post-validation (88-100%)
+  
+  // Outcome
+  lastSessionOutcome: SessionOutcome;
+  lastSessionSummary: SessionSummary | null;
+}
+
+interface PersistentData {
+  maxRetries: number;       // Max retry attempts (1-50)
+  autoRetryEnabled: boolean;
+  lastPromptValue: string;
+  videoGoal: number;        // Target videos to generate (1-50)
+  videoGroup: string[];     // Related post IDs
+  originalMediaId: string | null; // Original image ID for the session
+}
+```
+
+## Lifecycle Phases
+
+### 1. Session Initialization
+
+**Trigger:** User clicks "Generate Video" button in the extension panel
+
+**Actions:**
+1. Capture prompt from site textarea or use stored value
+2. Reset session counters (retryCount, videosGenerated, failures)
+3. Set `isSessionActive = true`
+4. Store session identity (postId/mediaId)
+5. **Capture and store original image ID** (`originalMediaId`) for the session
+6. Clear video history tracking
+7. Initialize progress tracking observer
+8. Perform first attempt with `overridePermit = true`
+
+**State Changes:**
+```typescript
+{
+  isSessionActive: true,
+  retryCount: 0,
+  videosGenerated: 0,
+  creditsUsed: 0,
+  layer1Failures: 0,
+  layer2Failures: 0,
+  layer3Failures: 0,
+  canRetry: false,
+  lastSessionOutcome: 'pending'
+}
+```
+
+### 2. Video Attempt
+
+**Process:**
+1. Write prompt value to site textarea
+2. Find and click "Make video" button
+3. Record attempt timestamp (keyed by mediaId if present)
+4. Start 8-second cooldown timer
+5. Begin progress tracking via MutationObserver
+6. Reset `canRetry = false` (consumed)
+
+**Guards:**
+- Cooldown check: `now - lastClickTime >= 8000ms`
+- Permit check: `canRetry === true || overridePermit === true`
+- Goal check: `videosGenerated < videoGoal`
+- Rate limit: Not in rate-limited state
+
+### 3. Outcome Detection
+
+Two parallel detection mechanisms:
+
+#### A. Success Detection
+- **Stream-based:** Monitor GraphQL responses for completed video streams
+- **DOM-based:** Fallback polling for video elements in page structure
+- **Trigger:** Either mechanism fires `onSuccess()` callback
+
+#### B. Failure Detection
+- **Primary:** Toast notification monitoring for "Content Moderated" message
+- **Fallback:** Body text scanning
+- **Trigger:** Fires `onModerationDetected()` callback
+
+**On Success:**
+```typescript
+incrementVideosGenerated();
+creditsUsed++;
+
+if (videosGenerated >= videoGoal) {
+  endSession('success');
+} else {
+  // Wait 8 seconds, then continue
+  setTimeout(() => {
+    clickMakeVideoButton(lastPromptValue, { overridePermit: true });
+  }, 8000);
+}
+```
+
+**On Failure:**
+```typescript
+const progress = parseProgressPercentage(); // From progress button
+const layer = classifyLayer(progress);
+layer1Failures += (layer === 1) ? 1 : 0;
+layer2Failures += (layer === 2) ? 1 : 0;
+layer3Failures += (layer === 3) ? 1 : 0;
+creditsUsed++;
+canRetry = true; // Enable retry permission
+```
+
+### 4. Moderation Layer Classification
+
+Progress percentage determines which security layer blocked the video:
+
+| Progress % | Layer | Description |
+|------------|-------|-------------|
+| 0-24% | **Layer 1** | Prompt Filtering - blocked before generation |
+| 25-87% | **Layer 2** | Model-Level Alignment - refused mid-stream |
+| 88-100% | **Layer 3** | Post-Generation Validation - blocked after render |
+
+### 5. Retry Scheduling
+
+**Scheduler Loop** (runs every 3 seconds when session active):
+
+```typescript
+if (autoRetryEnabled && isSessionActive && canRetry) {
+  if (retryCount < maxRetries) {
+    if (videosGenerated >= videoGoal) {
+      endSession('success');
+    } else if (cooldownExpired && hasPermit) {
+      retryCount++;
+      canRetry = false;
+      clickMakeVideoButton(lastPromptValue, { overridePermit: true });
+    }
+  } else {
+    endSession('failure'); // Max retries exceeded
+  }
+}
+```
+
+**Timeout Protection:**
+- If no success/failure detected for 2 minutes → `endSession('cancelled')`
+
+### 6. Multi-Video Generation
+
+When `videoGoal > 1`:
+
+1. Each successful video increments `videosGenerated`
+2. Session continues until `videosGenerated >= videoGoal`
+3. Each video uses the **same prompt** from session start
+4. 8-second delay between videos (same as retry cooldown)
+5. Retries **do not reset** between videos (applies to whole session)
+
+**Example Flow (videoGoal = 3, maxRetries = 5):**
+```
+Attempt 1 → Success (1/3) → Wait 8s
+Attempt 2 → Failure (1/3, retry 1/5) → Wait 8s
+Attempt 3 → Success (2/3, retry 1/5) → Wait 8s
+Attempt 4 → Success (3/3) → End session (success)
+```
+
+### 7. Session Termination
+
+**Outcomes:**
+
+| Outcome | Trigger |
+|---------|---------|
+| `success` | Video goal reached |
+| `failure` | Max retries exceeded |
+| `cancelled` | User cancels, rate limit, or timeout |
+| `idle` | Default/clean state |
+
+**Cleanup Actions:**
+1. Create session summary with final stats
+2. **Clear all video attempts sharing the same originalMediaId** (from grokStream, chrome.storage, and sessionStorage)
+3. Reset session flags (`isSessionActive = false`)
+4. Clear session counters
+5. Clear session identity from window
+6. Clear video group chain
+7. Stop progress observer
+8. Cancel any pending timeouts
+
+**Session Summary:**
+```typescript
+{
+  outcome: 'success',
+  completedVideos: 3,
+  videoGoal: 3,
+  retriesAttempted: 1,
+  maxRetries: 5,
+  creditsUsed: 4,
+  layer1Failures: 0,
+  layer2Failures: 1,
+  layer3Failures: 0,
+  endedAt: 1738512000000
+}
+```
+
+## State Persistence
+
+### Chrome Storage (chrome.storage.local)
+**Persistent across browser sessions:**
+- `maxRetries`
+- `autoRetryEnabled`
+- `lastPromptValue`
+- `videoGoal`
+- `videoGroup`
+- `originalMediaId` - **Original image ID that started the session** (ensures all video attempts reference the same source image)
+
+### Session Storage (sessionStorage)
+**Cleared on page refresh:**
+- `retryCount`
+- `isSessionActive`
+- `videosGenerated`
+- `canRetry`
+- `logs`
+- `attemptProgress`
+- `creditsUsed`
+- `layer1Failures`, `layer2Failures`, `layer3Failures`
+- `lastSessionOutcome`
+- `lastSessionSummary`
+
+### Window Globals (Debugging)
+```typescript
+window.__grok_session_post_id    // Current session post ID
+window.__grok_session_media_id   // Current session media ID (preserved across videos)
+window.__grok_retryState         // Live retry state snapshot (includes originalMediaId)
+window.__grok_attempts           // Attempt timestamps by key
+window.__grok_canRetry           // Permit flag
+```
+
+## Original Image ID Preservation
+
+When generating multiple videos from a single image (videoGoal > 1), it's critical that all video generation attempts reference the **same source image**. The extension ensures this by:
+
+1. **Capturing the original image ID** - When a session starts, the `mediaId` (extracted from the image URL) is stored as `originalMediaId` in persistent storage
+2. **Preserving across route changes** - When Grok navigates to new post routes after successful videos, the original `mediaId` is maintained via `window.__grok_session_media_id`
+3. **Consistent video generation** - All subsequent video attempts in the session use the stored `originalMediaId`, not the newly detected image from the DOM
+
+This ensures that:
+- All videos in a multi-video session are generated from the **same source image**
+- The video generation API receives consistent `imageReference` data
+- Users can reliably generate variations of videos from a single image
+- Session continuity is maintained even when the UI navigates to new pages
+
+## Edge Cases & Guardrails
+
+### Route Changes
+- Session identity (postId/mediaId) persists across route changes
+- Prompt and settings saved to chrome.storage for continuity
+- State migration function available at `window.__grok_migrate_state`
+
+### Cooldown Enforcement
+- Single scheduled retry if click attempted during cooldown
+- Prevents spam clicks from queuing multiple retries
+- Timeout cleared if new click requested
+
+### Duplicate Detection
+- Stream success tracking prevents duplicate success callbacks
+- Toast text comparison prevents duplicate moderation callbacks
+- 5-second minimum between moderation callbacks
+
+### Rate Limits
+- Immediate session cancellation on rate limit detection
+- No retry attempts when rate limited
+
+### Session Timeout
+- 2-minute maximum without feedback
+- Auto-cancels to prevent hung sessions
+
+## Integration Points
+
+### Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `useGrokRetry` | Core session management and state |
+| `useSuccessDetector` | Monitors for successful video generation |
+| `useModerationDetector` | Monitors for moderation/rate limit notices |
+| `useSessionStorage` | Manages persistent and session data |
+| `usePageTitle` | Updates page title with session progress |
+
+### Key Functions
+
+| Function | Description |
+|----------|-------------|
+| `startSession(prompt?)` | Initialize new session |
+| `endSession(outcome)` | Terminate session with outcome |
+| `clickMakeVideoButton(prompt, options)` | Attempt video generation |
+| `markFailureDetected()` | Process moderation failure |
+| `incrementVideosGenerated()` | Record successful video |
+| `resetRetries()` | Clear retry counter (user action) |
+
+## Debugging
+
+Enable debug logging in the extension panel to see:
+- Session lifecycle events
+- Retry attempts and cooldowns
+- Moderation layer classifications
+- Success/failure detection events
+- State transitions
+
+Access test bridge:
+```javascript
+window.__grok_test.startSession()
+window.__grok_test.endSession('success')
+window.__grok_test.markFailureDetected()
+```
+
+## Performance Considerations
+
+- **Scheduler interval:** 3 seconds (balances responsiveness vs CPU)
+- **Cooldown period:** 8 seconds (respects platform rate limits)
+- **Progress records:** Maximum 25 entries (prevents memory bloat)
+- **Log entries:** Maximum 200 lines (auto-truncates oldest)
+- **Session timeout:** 2 minutes (prevents zombie sessions)
+
+## Future Enhancements
+
+Potential improvements to the lifecycle:
+
+1. **Adaptive cooldowns** based on success rate
+2. **Smart prompt adjustments** after Layer 1 failures
+3. **Batch session summaries** across multiple posts
+4. **Exponential backoff** for repeated failures
+5. **Pre-flight prompt validation** before attempts

--- a/extension/src/hooks/usePostId.ts
+++ b/extension/src/hooks/usePostId.ts
@@ -165,6 +165,7 @@ export const usePostId = (): PostRouteIdentity => {
                     delete w.__grok_pending_route_eval;
 
                     // Trigger migration from old post to new post
+                    // Preserve the original sessionMediaId to ensure all videos reference the same source image
                     if (w.__grok_migrate_state) {
                         w.__grok_migrate_state(sessionPostId, urlPostId, {
                             fromSessionKey: sessionMediaId ?? sessionPostId,
@@ -172,9 +173,12 @@ export const usePostId = (): PostRouteIdentity => {
                         });
                     }
 
-                    // Update session tracking to use new post ID
+                    // Update session tracking to use new post ID, but keep original media ID
                     w.__grok_session_post_id = urlPostId;
-                    w.__grok_session_media_id = nextMediaId ?? sessionMediaId ?? null;
+                    // Preserve sessionMediaId (original image ID) rather than replacing with nextMediaId
+                    if (!w.__grok_session_media_id && sessionMediaId) {
+                        w.__grok_session_media_id = sessionMediaId;
+                    }
 
                     // Clear route change flag
                     delete w.__grok_route_changed;

--- a/extension/src/hooks/useSessionStorage.ts
+++ b/extension/src/hooks/useSessionStorage.ts
@@ -9,6 +9,7 @@ interface PersistentData {
     lastPromptValue: string;
     videoGoal: number;
     videoGroup: string[]; // Array of related post IDs in this video generation session
+    originalMediaId: string | null; // Original image ID that started the video generation session
 }
 
 export type SessionOutcome = 'idle' | 'pending' | 'success' | 'failure' | 'cancelled';
@@ -68,6 +69,7 @@ const createDefaultPostData = (): PostData => ({
     lastPromptValue: '',
     videoGoal: 1,
     videoGroup: [],
+    originalMediaId: null,
     retryCount: 0,
     isSessionActive: false,
     videosGenerated: 0,
@@ -133,6 +135,7 @@ export const usePostStorage = (postId: string | null, mediaId: string | null) =>
                 lastPromptValue: '',
                 videoGoal: globalSettings.defaultVideoGoal ?? 1,
                 videoGroup: [],
+                originalMediaId: null,
             };
 
             const DEFAULT_SESSION_DATA: SessionData = {


### PR DESCRIPTION
This pull request introduces significant improvements to the reliability and consistency of the "Grok Retry" video generation session management, especially around prompt submission and session cleanup. The changes focus on robust handling of prompt retries, ensuring all video attempts in a session reference the correct original image, and comprehensive clearing of session state across different storage layers.

**Session management and cleanup improvements:**

* Added tracking of `originalMediaId` to all session data, ensuring that all video attempts in a session are consistently tied to the same source image. This value is now preserved across navigation and migration events. [[1]](diffhunk://#diff-c619fdcc7dc53ba379cd898d5150ac08106e43ff7d0461479583dbde3ee011fbR106-R114) [[2]](diffhunk://#diff-c619fdcc7dc53ba379cd898d5150ac08106e43ff7d0461479583dbde3ee011fbR208-R218) [[3]](diffhunk://#diff-35b17619433bbf777970bc49f62675570b87169425ceb3559e56158bf51d5a40R12) [[4]](diffhunk://#diff-35b17619433bbf777970bc49f62675570b87169425ceb3559e56158bf51d5a40R72) [[5]](diffhunk://#diff-a8cfc4bb24f7266fc2cdd7eca1d74a865751b8de2b16dc7b02cfe1e557ed1e62R168-R181)
* Implemented `clearVideoAttemptsByMediaId` and `clearVideoGroupChain` functions to comprehensively clear all video attempts and related session state for a given image across `window`, `chrome.storage.local`, and `sessionStorage`. These are invoked when a session ends to prevent stale or conflicting session data. [[1]](diffhunk://#diff-c619fdcc7dc53ba379cd898d5150ac08106e43ff7d0461479583dbde3ee011fbR254-R417) [[2]](diffhunk://#diff-c619fdcc7dc53ba379cd898d5150ac08106e43ff7d0461479583dbde3ee011fbR430-R436)
* Updated the session end logic to use these new clearing functions and ensure all related session data is reset, including disabling further retries and clearing the video group.

**Robust prompt submission and retry logic:**

* Added logic to reliably submit prompts to either inline editors or the main bottom prompt area, with fallback and retry mechanisms if the preferred method is not available. This includes queueing prompts for retry after navigation and robustly locating the correct editor for a given prompt. [[1]](diffhunk://#diff-5044e93f5d58c5ef5fae7961d6365d9f3dd1f255b65194fd8d779aba90aede8cR544-R696) [[2]](diffhunk://#diff-5044e93f5d58c5ef5fae7961d6365d9f3dd1f255b65194fd8d779aba90aede8cR756-R815) [[3]](diffhunk://#diff-5044e93f5d58c5ef5fae7961d6365d9f3dd1f255b65194fd8d779aba90aede8cR95-R102)
* Ensured that prompt values are normalized and matched with inline sections more accurately, improving the reliability of prompt resubmission after navigation or interruptions.

**Code organization and dependency updates:**

* Updated imports and dependencies to support the new prompt writing and session clearing logic. [[1]](diffhunk://#diff-5044e93f5d58c5ef5fae7961d6365d9f3dd1f255b65194fd8d779aba90aede8cR17) [[2]](diffhunk://#diff-c619fdcc7dc53ba379cd898d5150ac08106e43ff7d0461479583dbde3ee011fbR7-R13)

These changes collectively enhance the stability and user experience of the video generation retry workflow, making it more resilient to navigation, failures, and multi-step sessions.